### PR TITLE
Fix popin and menu placement

### DIFF
--- a/static/css/responsive-kansha.css
+++ b/static/css/responsive-kansha.css
@@ -61,6 +61,7 @@ a:active {
     position: fixed;
     margin-bottom: 0;
     height: auto;
+    z-index: 25;
 }
 
 .navbar .tab {

--- a/static/css/responsive-kansha.css
+++ b/static/css/responsive-kansha.css
@@ -47,7 +47,7 @@ a:active {
     background: none repeat scroll 0 0 #000;
     height: 100%;
     opacity: 0.55;
-    position: absolute;
+    position: fixed;
     width: 100%;
     z-index: 25;
     display: none;
@@ -58,7 +58,7 @@ a:active {
 }
 
 .navbar {
-    position: absolute;
+    position: fixed;
     margin-bottom: 0;
     height: auto;
 }
@@ -283,6 +283,8 @@ a:active {
 
 .board .header {
     text-align: right;
+    position: fixed;
+    width: 100%;
 }
 
 .board .header .nagare-generated {

--- a/static/js/kansha.js
+++ b/static/js/kansha.js
@@ -149,7 +149,7 @@
             var zone = ECN('navActions', '', navId)[0];
             if (Dom.hasClass(tab, 'expand')[0]) {
                 nextMarginTop = -zone.clientHeight;
-                Dom.setStyle(navId, 'z-index', 'auto');
+                Dom.setStyle(navId, 'z-index', 25);
                 Dom.replaceClass(tab, 'tab expand', 'tab collapse');
                 Dom.setStyle('mask', 'display', 'none');
             } else {

--- a/static/js/kansha.js
+++ b/static/js/kansha.js
@@ -328,8 +328,6 @@
                 // Add listener on the Esc key
                 keylisteners: new YAHOO.util.KeyListener(document, {keys: 27}, NS.app.closePopin, 'keyup')
             });
-            // No top/left offset
-            NS.app.popin.cfg.setProperty("x", 0);
             // Register the close function
             NS.app.closePopinFunction = closeFunction;
             // Render the panel


### PR DESCRIPTION
When a board has many columns so that you have to scroll to reach the most right columns, the top menu is not visible anymore (it stays on the left) and any attempt to open a card in these will result in the popin showing not properly.