### PR TITLE
Add default username and password in config for DB auth

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -114,6 +114,9 @@ Kansha features can be activated and customized with a configuration file like t
     activated = <<AUTH_DB>>
     # moderator email if needed
     moderator = <<MOD_EMAIL>> # or empty
+    # default values to fill in the login form (useful for a demo board)
+    default_username = <<DEFAULT_USERNAME>>
+    default_password = <<DEFAULT_PASSWORD>>
 
     # authenticate with LDAP
     [ldapauth]

--- a/kansha/app/app.py
+++ b/kansha/app/app.py
@@ -178,7 +178,9 @@ class WSGIApp(wsgi.WSGIApp):
                         'title': 'string(default="")',
                         'custom_css': 'string(default="")'},
         'dbauth': {'activated': 'boolean(default=True)',
-                   'moderator': 'string(default="")'},
+                   'moderator': 'string(default=""),',
+                   'default_username': 'string(default="")',
+                   'default_password': 'string(default="")'},
         'oauth': {
             'activated': 'boolean(default=False)',
             'google': {'activated': 'boolean(default=True)',

--- a/kansha/authentication/database/forms.py
+++ b/kansha/authentication/database/forms.py
@@ -63,9 +63,11 @@ def redirect_to(url):
 
 class Login(object):
 
-    def __init__(self, app_title, custom_css, mail_sender, moderator=''):
+    def __init__(self, app_title, custom_css, mail_sender, config):
         self.error_message = ''
-        self.registration_task = RegistrationTask(app_title, custom_css, mail_sender, moderator)
+        self.registration_task = RegistrationTask(app_title, custom_css, mail_sender, config.get('moderator', ''))
+        self.default_username = config.get('default_username', u'')
+        self.default_password = config.get('default_password', u'')
         self.pwd_reset = PasswordResetTask(app_title, custom_css, mail_sender)
         self.content = component.Component()
 
@@ -99,9 +101,9 @@ def render_Login_form(self, h, comp, *args):
             if self.error_message:
                 h << h.br << h.div(self.error_message, class_="error")
             h << h.label(_("username"), for_="username")
-            h << h.input(type='text', name='__ac_name', id="username")
+            h << h.input(type='text', name='__ac_name', id="username", value=self.default_username)
             h << h.label(_("password"), for_="password")
-            h << h.input(type='password', name='__ac_password', id="password")
+            h << h.input(type='password', name='__ac_password', id="password", value=self.default_password)
             with h.div(class_='actions'):
                 h << h.input(type='submit', value=u'OK', class_="btn btn-primary btn-small").action(self.log_in, comp)
             h << h.a(_('Forgot your Password?')).action(self.content.call, self.pwd_reset)

--- a/kansha/authentication/database/forms.py
+++ b/kansha/authentication/database/forms.py
@@ -65,9 +65,9 @@ class Login(object):
 
     def __init__(self, app_title, custom_css, mail_sender, config):
         self.error_message = ''
-        self.registration_task = RegistrationTask(app_title, custom_css, mail_sender, config.get('moderator', ''))
-        self.default_username = config.get('default_username', u'')
-        self.default_password = config.get('default_password', u'')
+        self.registration_task = RegistrationTask(app_title, custom_css, mail_sender, config['moderator'])
+        self.default_username = config['default_username']
+        self.default_password = config['default_password']
         self.pwd_reset = PasswordResetTask(app_title, custom_css, mail_sender)
         self.content = component.Component()
 

--- a/kansha/authentication/login.py
+++ b/kansha/authentication/login.py
@@ -85,7 +85,7 @@ class Login(object):
         """
         logins = []
         if auth_cfg['dbauth']['activated']:
-            logins.append(database_form.Login(app_title, custom_css, mail_sender, auth_cfg['dbauth']['moderator']))
+            logins.append(database_form.Login(app_title, custom_css, mail_sender, auth_cfg['dbauth']))
         if auth_cfg['oauth']['activated']:
             logins.append(oauth.Login(auth_cfg['oauth']))
         if auth_cfg['ldapauth']['activated']:


### PR DESCRIPTION
Add default_username and default_password in the config file to have the DB auth login form prefilled with these values.
The user then just has to click "OK" on the form to login (example use in a demo environment).