### PR TITLE
Fix elasticsearch search engine and tests

### DIFF
--- a/kansha/services/search/elasticengine.py
+++ b/kansha/services/search/elasticengine.py
@@ -13,8 +13,13 @@ Depends on a running ElasticSearch cluster, somewhere.
 For usage, look at the unit tests.
 """
 
-from elasticsearch import Elasticsearch, helpers
-from elasticsearch.client import IndicesClient
+try:
+    from elasticsearch import Elasticsearch, helpers
+    from elasticsearch.client import IndicesClient
+except ImportError:
+    es_installed = False
+else:
+    es_installed = True
 
 from . import schema
 
@@ -109,6 +114,7 @@ class ElasticSearchEngine(object):
 
     def __init__(self, index, host=None, port=None):
         '''Only one host for now.'''
+        assert es_installed, 'elasticsearch not installed'
         assert(index.isalpha())
         self.init_state(index, host, port)
 

--- a/kansha/services/search/elasticengine.py
+++ b/kansha/services/search/elasticengine.py
@@ -114,7 +114,9 @@ class ElasticSearchEngine(object):
 
     def __init__(self, index, host=None, port=None):
         '''Only one host for now.'''
-        assert es_installed, 'elasticsearch not installed'
+        if not es_installed:
+            raise ValueError('elasticsearch not installed')
+
         assert(index.isalpha())
         self.init_state(index, host, port)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -188,5 +188,8 @@ class TestSQLiteEngine(unittest.TestCase):
 class TestElasticEngine(TestSQLiteEngine):
 
     def setUp(self):
-        self.engine = elasticengine.ElasticSearchEngine(self.collection)
+        try:
+            self.engine = elasticengine.ElasticSearchEngine(self.collection)
+        except ValueError as exc:
+            self.skipTest(unicode(exc))
         self.engine.create_collection([MyDocument, Person])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -59,14 +59,15 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(doc.price, 5.6, u'attribute not set')
 
 
-class TestSQLiteEngine(unittest.TestCase):
+class SearchTestCase(object):
 
     collection = u'test'
-    index_folder = u'/tmp'
+
+    def _create_search_engine(self):
+        raise NotImplementedError()
 
     def setUp(self):
-        self.engine = sqliteengine.SQLiteFTSEngine(
-            self.collection, self.index_folder)
+        self.engine = self._create_search_engine()
         self.engine.create_collection([MyDocument, Person])
 
     def tearDown(self):
@@ -181,15 +182,16 @@ class TestSQLiteEngine(unittest.TestCase):
         self.assertEqual(len(res), 2)
 
 
+class TestSQLiteEngine(SearchTestCase, unittest.TestCase):
 
-    # TODO: test other query (==, >, <, ....)
+    def _create_search_engine(self):
+        return sqliteengine.SQLiteFTSEngine(self.collection, u'/tmp')
 
 
-class TestElasticEngine(TestSQLiteEngine):
+class TestElasticEngine(SearchTestCase, unittest.TestCase):
 
-    def setUp(self):
+    def _create_search_engine(self):
         try:
-            self.engine = elasticengine.ElasticSearchEngine(self.collection)
+            return elasticengine.ElasticSearchEngine(self.collection)
         except ValueError as exc:
             self.skipTest(unicode(exc))
-        self.engine.create_collection([MyDocument, Person])


### PR DESCRIPTION
elasticsearch is not mandatory, its tests should be skipped when it is not installed.