### PR TITLE
Added a "Back to home" link on the Kansha logo

### DIFF
--- a/kansha/authentication/database/forms.py
+++ b/kansha/authentication/database/forms.py
@@ -48,7 +48,6 @@ def render_Header(self, h, comp, *args):
     with h.div(class_='header'):
         with h.a(href=h.request.application_url):
             h << h.div(class_='logo')
-        # h << h.div(class_='logo')
         h << h.h1(self.app_banner)
     return h.root
 

--- a/kansha/authentication/database/forms.py
+++ b/kansha/authentication/database/forms.py
@@ -46,7 +46,9 @@ def render_Header(self, h, comp, *args):
         h.head.css_url(self.custom_css)
 
     with h.div(class_='header'):
-        h << h.div(class_='logo')
+        with h.a(href=h.request.application_url):
+            h << h.div(class_='logo')
+        # h << h.div(class_='logo')
         h << h.h1(self.app_banner)
     return h.root
 

--- a/kansha/authentication/login.py
+++ b/kansha/authentication/login.py
@@ -40,7 +40,8 @@ def render_Header(self, h, comp, *args):
         h.head.css_url(self.custom_css)
 
     with h.div(class_='header'):
-        h << h.div(class_='logo')
+        with h.a(href=h.request.application_url):
+            h << h.div(class_='logo')
         h << h.h1(self.banner)
     return h.root
 


### PR DESCRIPTION
Having a link on a website's logo to go back to the home page is a common feature but it's missing on Kansha on various pages (login, password recovery, email confirmation, etc).

Here is my proposal to add such a feature to Kansha.