### PR TITLE
add set_options to ReIndex

### DIFF
--- a/kansha/batch/create_index.py
+++ b/kansha/batch/create_index.py
@@ -48,6 +48,10 @@ class ReIndex(command.Command):
     desc = '(Re-)Create index for the application.'
 
     @staticmethod
+    def set_options(optparser):
+        optparser.usage += ' [application]'
+
+    @staticmethod
     def run(parser, options, args):
 
         try:


### PR DESCRIPTION
`kansha-admin create-index -h` now displays:
```
Usage: kansha-admin create-index [application]

Options:
  -h, --help  show this help message and exit
```