### PR TITLE
Fix issue #47

### DIFF
--- a/kansha/gallery/view.py
+++ b/kansha/gallery/view.py
@@ -169,13 +169,19 @@ def render_overlay_menu(self, h, comp, *args):
                     h << h.li(h.a(_('Remove cover')).action(
                         lambda: comp.answer(('remove_cover', self))))
                 else:
-                    h << h.li(h.a(_('Make cover')).action(
-                        ajax.Update(
-                            render=lambda h: comp.render(h),
-                            action=lambda: self.crop(comp, card_cmp, card_id, card_model),
-                            component_to_update=id_)
-                    )
-                    )
+                    # Open asset cropper
+                    card_cmp = h.get_async_root().component
+                    card_id = h.get_async_root().id
+                    card_model = h.get_async_root().model
+
+                    self.create_cropper_component(comp, card_cmp, card_id, card_model)
+                    h << h.li(self.overlay_cropper)
+    return h.root
+
+
+@presentation.render_for(Asset, 'cropper_menu')
+def render_asset_cropper_menu(self, h, comp, *args):
+    h << h.span(_('Make cover'))
     return h.root
 
 

--- a/kansha/toolbox/overlay.py
+++ b/kansha/toolbox/overlay.py
@@ -17,7 +17,7 @@ class Overlay(object):
     """Overlay component
     """
 
-    def __init__(self, text_factory, content_factory, title=None, dynamic=True, cls=None):
+    def __init__(self, text_factory, content_factory, title=None, dynamic=True, cls=None, centered=False):
         """Initialization
 
         In:
@@ -32,6 +32,7 @@ class Overlay(object):
         self.title = title
         self.dynamic = dynamic
         self.cls = cls
+        self.centered = centered
 
     def render_a(self, h, link_id):
         h << h.a(self.text(h), href='#', id_=link_id, title=self.title or '')
@@ -65,11 +66,12 @@ def render(self, h, comp, *args):
 
     js = ajax.js(
         "%(load)s;"
-        "YAHOO.kansha.app.showOverlay(%(overlay_id)s, %(link_id)s)" %
+        "YAHOO.kansha.app.showOverlay(%(overlay_id)s, %(link_id)s, %(centered)s)" %
         {
             'load': ajax.py2js(load),
             'link_id': ajax.py2js(link_id),
-            'overlay_id': ajax.py2js(overlay_id)
+            'overlay_id': ajax.py2js(overlay_id),
+            'centered': ajax.py2js(self.centered, h)
         }
     )
 
@@ -81,6 +83,8 @@ def render(self, h, comp, *args):
     )
 
     cls = [u'overlay']
+    if not self.centered:
+        cls.append(u'overlay_arrow')
     if self.cls:
         cls.append(self.cls)
     with h.div(class_=u' '.join(cls), id=overlay_id, onclick="YAHOO.kansha.app.stopEvent()"):

--- a/static/css/responsive-kansha.css
+++ b/static/css/responsive-kansha.css
@@ -549,7 +549,7 @@ span.nomatches {
     box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.13);
 }
 
-.overlay:before {
+.overlay_arrow:before {
     border-bottom: 7px solid rgba(0, 0, 0, 0.1);
     border-left: 7px solid transparent;
     border-right: 7px solid transparent;
@@ -560,7 +560,7 @@ span.nomatches {
     top: -7px;
 }
 
-.overlay:after {
+.overlay_arrow:after {
     border-bottom: 6px solid #FFFFFF;
     border-left: 6px solid transparent;
     border-right: 6px solid transparent;

--- a/static/js/kansha.js
+++ b/static/js/kansha.js
@@ -291,7 +291,7 @@
             Event.stopEvent(ev);
         },
 
-        showOverlay: function (overlay_id, link_id) {
+        showOverlay: function (overlay_id, link_id, centered) {
             var ev = Event.getEvent();
             Event.stopEvent(ev);
             NS.app.hideOverlay();
@@ -307,6 +307,9 @@
                     visible: true,
                     constraintoviewport: true});
             NS.app.overlay.render(document.body);
+            if (centered){
+            	NS.app.overlay.center();
+            }
             NS.app.overlay.show();
         },
 


### PR DESCRIPTION
Display image cropper component in its own overlay instead of replacing the image menu overlay.
Image cropper overlay is centered in the window