### PR TITLE
Identicons

### DIFF
--- a/doc/production.rst
+++ b/doc/production.rst
@@ -38,13 +38,11 @@ Then configure Kansha (:ref:`configuration_guide`).
 
 In any case, you always need to::
 
-    $ <VENV_DIR>/bin/nagare-admin create-db --no-populate </path/to/your/kansha.cfg>
+    $ <VENV_DIR>/bin/nagare-admin create-db </path/to/your/kansha.cfg>
     $ <VENV_DIR>/bin/kansha-admin alembic-stamp head </path/to/your/kansha.cfg>
     $ <VENV_DIR>/bin/kansha-admin create-index </path/to/your/kansha.cfg>
 
 When you **first** deploy.
-
-The ``--no-populate`` option ensures that the default users (*user1*, *user2* and *user3*) are not created.
 
 Deployment behind a web server
 ------------------------------

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -105,6 +105,7 @@ To get quickly up and running, let's use the built-in web server, database and s
 
     $ nagare-admin create-db kansha
     $ kansha-admin alembic-stamp head
+    $ kansha-admin create-demo  # optional, create demo users and contents
 
 2. Build the search indexes (can be safely repeated anytime)::
 

--- a/kansha/app/comp.py
+++ b/kansha/app/comp.py
@@ -245,6 +245,9 @@ class WSGIApp(wsgi.WSGIApp):
         self._services.register('search_engine', self.search_engine)
         Card.update_schema(self.card_extensions)
 
+        # Make assets_manager available to kansha-admin commands
+        self.assets_manager = self._services['assets_manager']
+
         # other
         self.security = SecurityManager(conf['application']['crypto_key'])
         self.debug = conf['application']['debug']

--- a/kansha/authentication/database/forms.py
+++ b/kansha/authentication/database/forms.py
@@ -112,17 +112,6 @@ class Login(Authentication):
             security.set_user(None)
             u = None
         if u is not None:
-            if not u.has_avatar():
-                identicon = retricon(u.email.encode(), tiles=7, width=140)
-                icon_file = BytesIO()
-                identicon.save(icon_file, 'PNG')
-                uid = u.username
-                self.assets_manager.save(
-                    icon_file.getvalue(),
-                    uid,
-                    {'filename': '%s.png' % uid})
-                picture = self.assets_manager.get_image_url(uid, 'thumb')
-                u.data.picture = picture
             database.session.flush()
             comp.answer(u)
         else:
@@ -160,7 +149,8 @@ class RegistrationForm(editor.Editor):
 
     """Registration form for creating a new (unconfirmed) user"""
 
-    def __init__(self, app_title, app_banner, theme):
+    def __init__(self, app_title, app_banner, theme, assets_manager_service):
+        self.assets_manager = assets_manager_service
         self.username = editor.Property('').validate(self.validate_username)
         self.email = editor.Property('').validate(validator.validate_email)
         self.fullname = editor.Property('').validate(validator.validate_non_empty_string)
@@ -212,11 +202,22 @@ class RegistrationForm(editor.Editor):
             self.error_message = _(u'Unable to process. Check your input below.')
             return None
 
+        identicon = retricon(self.email.value.encode(), tiles=7, width=140)
+        icon_file = BytesIO()
+        identicon.save(icon_file, 'PNG')
+        uid = self.username.value
+        self.assets_manager.save(
+            icon_file.getvalue(),
+            uid,
+            {'filename': '%s.png' % uid})
+        picture = self.assets_manager.get_image_url(uid, 'thumb')
+
         # register the user in the database
-        u = self.user_manager.create_user(username=self.username.value,
+        u = self.user_manager.create_user(username=uid,
                                           password=self.password.value,
                                           fullname=self.fullname.value,
-                                          email=self.email.value)
+                                          email=self.email.value,
+                                          picture=picture)
         return u
 
     def on_ok(self, comp, application_url):
@@ -882,7 +883,7 @@ class RegistrationTask(component.Task):
 
     """A task that handles the user registration process"""
 
-    def __init__(self, app_title, app_banner, theme, mail_sender_service, moderator='', username=''):
+    def __init__(self, app_title, app_banner, theme, mail_sender_service, assets_manager_service, moderator='', username=''):
         '''
         Register a new user (`username` not provided)
         or register email for an existing unconfirmed user (`username` provided).
@@ -892,6 +893,7 @@ class RegistrationTask(component.Task):
         self.app_banner = app_banner
         self.theme = theme
         self.mail_sender = mail_sender_service
+        self.assets_manager = assets_manager_service
         self.moderator = moderator
         self.state = None  # task state, initialized by a URL rule
         self.user_manager = usermanager.UserManager()
@@ -918,7 +920,7 @@ class RegistrationTask(component.Task):
                     )
                 )
             else:
-                username, application_url = comp.call(RegistrationForm(self.app_title, self.app_banner, self.theme))
+                username, application_url = comp.call(RegistrationForm(self.app_title, self.app_banner, self.theme, self.assets_manager))
             if username:
                 confirmation = self._create_email_confirmation(username, application_url)
                 confirmation.send_email(self.mail_sender)

--- a/kansha/batch/create_demo.py
+++ b/kansha/batch/create_demo.py
@@ -1,0 +1,93 @@
+#--
+# Copyright (c) 2008-2013 Net-ng.
+# All rights reserved.
+#
+# This software is licensed under the BSD License, as described in
+# the file LICENSE.txt, which you should have received as part of
+# this distribution.
+#--
+
+#--
+# Copyright (c) 2012-2015 Net-ng.
+# All rights reserved.
+#
+# This software is licensed under the BSD License, as described in
+# the file LICENSE.txt, which you should have received as part of
+# this distribution.
+#--
+
+
+"""
+Create and (re)build the search index for cards.
+It is safe to run it anytime.
+Registered as a nagare-admin command.
+Usage :
+nagare-admin create-index <app name | config file>
+"""
+from io import BytesIO
+
+from retricon import retricon
+import pkg_resources
+
+from nagare import database
+from nagare.admin import util, command
+
+from kansha.user.usermanager import UserManager
+
+
+# FIXME: too low level
+def create_demo(app):
+    # demo users
+    user_manager = UserManager()
+    assets_manager = app.assets_manager
+    for i in xrange(1, 4):
+        email = u'user%d@net-ng.com' % i
+        username = u'user%d' % i
+        identicon = retricon(email.encode(), tiles=7, width=140)
+        icon_file = BytesIO()
+        identicon.save(icon_file, 'PNG')
+        assets_manager.save(
+            icon_file.getvalue(),
+            username,
+            {'filename': '%s.png' % username})
+        picture = assets_manager.get_image_url(username, 'thumb')
+        user = user_manager.create_user(username, u'password', u'user %d' % i, email, picture=picture)
+        user.confirm_email()
+    database.session.flush()
+    # demo templates
+    # TODO
+
+
+class CreateDemo(command.Command):
+
+    desc = 'Create demo users and contents.'
+
+    @staticmethod
+    def set_options(optparser):
+        optparser.usage += ' [application]'
+
+    @staticmethod
+    def run(parser, options, args):
+
+        try:
+            application = args[0]
+        except IndexError:
+            application = 'kansha'
+
+        (cfgfile, app, dist, conf) = util.read_application(application,
+                                                           parser.error)
+        requirement = (
+            None if not dist
+            else pkg_resources.Requirement.parse(dist.project_name)
+        )
+        data_path = (
+            None if not requirement
+            else pkg_resources.resource_filename(requirement, '/data')
+        )
+
+        (active_app, databases) = util.activate_WSGIApp(
+            app, cfgfile, conf, parser.error, data_path=data_path)
+        for (database_settings, populate) in databases:
+            database.set_metadata(*database_settings)
+        if active_app:
+            create_demo(active_app)

--- a/kansha/populate.py
+++ b/kansha/populate.py
@@ -9,7 +9,6 @@
 #--
 
 from .board.models import create_template_empty, create_template_todo
-from .user import usermanager
 
 
 def populate():
@@ -17,4 +16,3 @@ def populate():
     """
     create_template_empty()
     create_template_todo()
-    usermanager.UserManager().populate()

--- a/kansha/user/usermanager.py
+++ b/kansha/user/usermanager.py
@@ -90,12 +90,6 @@ class UserManager(object):
             token_gen.reset_token(token.token)
         return user
 
-    def populate(self):
-        # Create users
-        for i in xrange(1, 4):
-            user = self.create_user(u'user%d' % i, u'password', u'user %d' % i, u'user%d@net-ng.com' % i)
-            user.confirm_email()
-
 ###### TODO: Move the defintions below somewhere else ##########
 
 class NewMember(object):

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
       alembic-upgrade = kansha.alembic.admin:AlembicUpgradeCommand
       create-index = kansha.batch.create_index:ReIndex
       save-config = kansha.batch.save_config:SaveConfig
+      create-demo = kansha.batch.create_demo:CreateDemo
 
       [kansha.services]
       authentication = kansha.services.authentication_repository:AuthenticationsRepository

--- a/static/css/themes/home.css
+++ b/static/css/themes/home.css
@@ -24,6 +24,8 @@
     display: inline-block;
     visibility: hidden;
     overflow: hidden;
+    margin: 0;
+    padding: 0;
 }
 
 .home .boards ul.board-labels li:hover .add,

--- a/static/css/themes/kansha.css
+++ b/static/css/themes/kansha.css
@@ -124,8 +124,8 @@ i.icon {
 .board-labels .avatar img,
 .card .avatar img,
 .card-actions .avatar img {
-    max-height: 24px;
-    max-width: 24px;
+    max-height: 21px;
+    max-width: 21px;
 }
 
 /*Error page*/

--- a/static/css/themes/kansha.css
+++ b/static/css/themes/kansha.css
@@ -245,7 +245,7 @@ i.icon {
 }
 
 .avatar img {
-    max-width: 30px;
+    /*max-width: 30px;*/
     height: 28px;
     display: block
 }
@@ -481,7 +481,7 @@ i.icon {
 }
 
 .unselectable {
-    cursor: default
+    cursor: default;
 }
 
 .last-manager {

--- a/static/css/themes/kansha_flat/kansha.css
+++ b/static/css/themes/kansha_flat/kansha.css
@@ -162,7 +162,7 @@ a:hover .ico-btn {
 .board-labels i.ico-btn,
 .card i.ico-btn,
 .card-actions i.ico-btn {
-    font-size: 25px;
+    font-size: 21px;
 }
 
 /*Error page*/


### PR DESCRIPTION
- Create identicons for users registering thought 'Sign up' form. They can change it once logged on.
- Smaller avatars on cards and boards.
- Demo users are not created by default anymore, use `kansha-admint create-demo` if you need them.

Closes #179.

Here is a screenshot of how identicons look like. If you know an implementation/algorithm that gives better looking identicons, please leave a comment below.
![screenshot from 2016-02-05 11-27-14](https://cloud.githubusercontent.com/assets/7592443/12843764/be540354-cbfb-11e5-939f-2d1e774ec8c0.png)
