### PR TITLE
Identicons

### DIFF
--- a/doc/production.rst
+++ b/doc/production.rst
@@ -38,13 +38,11 @@ Then configure Kansha (:ref:`configuration_guide`).
 
 In any case, you always need to::
 
-    $ <VENV_DIR>/bin/nagare-admin create-db --no-populate </path/to/your/kansha.cfg>
+    $ <VENV_DIR>/bin/nagare-admin create-db </path/to/your/kansha.cfg>
     $ <VENV_DIR>/bin/kansha-admin alembic-stamp head </path/to/your/kansha.cfg>
     $ <VENV_DIR>/bin/kansha-admin create-index </path/to/your/kansha.cfg>
 
 When you **first** deploy.
-
-The ``--no-populate`` option ensures that the default users (*user1*, *user2* and *user3*) are not created.
 
 Deployment behind a web server
 ------------------------------

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -105,6 +105,7 @@ To get quickly up and running, let's use the built-in web server, database and s
 
     $ nagare-admin create-db kansha
     $ kansha-admin alembic-stamp head
+    $ kansha-admin create-demo  # optional, create demo users and contents
 
 2. Build the search indexes (can be safely repeated anytime)::
 

--- a/kansha/alembic/versions/55f89221fc55_email_index.py
+++ b/kansha/alembic/versions/55f89221fc55_email_index.py
@@ -1,0 +1,24 @@
+"""email index
+
+Revision ID: 55f89221fc55
+Revises: 25739bc150b9
+Create Date: 2017-01-24 16:44:02.500510
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '55f89221fc55'
+down_revision = '25739bc150b9'
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_email'), ['email'], unique=True)
+        batch_op.create_index(batch_op.f('ix_email_to_confirm'), ['email_to_confirm'], unique=True)
+
+
+def downgrade():
+    pass

--- a/kansha/app/comp.py
+++ b/kansha/app/comp.py
@@ -249,6 +249,9 @@ class WSGIApp(wsgi.WSGIApp):
         self._services.register('search_engine', self.search_engine)
         Card.update_schema(self.card_extensions)
 
+        # Make assets_manager available to kansha-admin commands
+        self.assets_manager = self._services['assets_manager']
+
         # other
         self.security = SecurityManager(conf['application']['crypto_key'])
         self.debug = conf['application']['debug']

--- a/kansha/authentication/database/forms.py
+++ b/kansha/authentication/database/forms.py
@@ -13,9 +13,6 @@ import hashlib
 import textwrap
 from datetime import datetime, timedelta
 
-from io import BytesIO
-from retricon import retricon
-
 import webob
 from nagare.i18n import _
 from nagare import (presentation, editor, component, security, log, database)
@@ -210,22 +207,13 @@ class RegistrationForm(editor.Editor):
             self.error_message = _(u'Unable to process. Check your input below.')
             return None
 
-        identicon = retricon(self.email.value.encode(), tiles=7, width=140)
-        icon_file = BytesIO()
-        identicon.save(icon_file, 'PNG')
-        uid = self.username.value
-        self.assets_manager.save(
-            icon_file.getvalue(),
-            uid,
-            {'filename': '%s.png' % uid})
-        picture = self.assets_manager.get_image_url(uid, 'thumb')
-
         # register the user in the database
-        u = self.user_manager.create_user(username=uid,
+        u = self.user_manager.create_user(username=self.username.value,
                                           password=self.password.value,
                                           fullname=self.fullname.value,
-                                          email=self.email.value,
-                                          picture=picture)
+                                          email=self.email.value)
+        appuser = self.user_manager.get_app_user(self.username.value, u)
+        appuser.reset_avatar(self.assets_manager)
         return u
 
     def on_ok(self, comp, application_url):

--- a/kansha/batch/create_demo.py
+++ b/kansha/batch/create_demo.py
@@ -1,0 +1,93 @@
+#--
+# Copyright (c) 2008-2013 Net-ng.
+# All rights reserved.
+#
+# This software is licensed under the BSD License, as described in
+# the file LICENSE.txt, which you should have received as part of
+# this distribution.
+#--
+
+#--
+# Copyright (c) 2012-2015 Net-ng.
+# All rights reserved.
+#
+# This software is licensed under the BSD License, as described in
+# the file LICENSE.txt, which you should have received as part of
+# this distribution.
+#--
+
+
+"""
+Create and (re)build the search index for cards.
+It is safe to run it anytime.
+Registered as a nagare-admin command.
+Usage :
+nagare-admin create-index <app name | config file>
+"""
+from io import BytesIO
+
+from retricon import retricon
+import pkg_resources
+
+from nagare import database
+from nagare.admin import util, command
+
+from kansha.user.usermanager import UserManager
+
+
+# FIXME: too low level
+def create_demo(app):
+    # demo users
+    user_manager = UserManager()
+    assets_manager = app.assets_manager
+    for i in xrange(1, 4):
+        email = u'user%d@net-ng.com' % i
+        username = u'user%d' % i
+        identicon = retricon(email.encode(), tiles=7, width=140)
+        icon_file = BytesIO()
+        identicon.save(icon_file, 'PNG')
+        assets_manager.save(
+            icon_file.getvalue(),
+            username,
+            {'filename': '%s.png' % username})
+        picture = assets_manager.get_image_url(username, 'thumb')
+        user = user_manager.create_user(username, u'password', u'user %d' % i, email, picture=picture)
+        user.confirm_email()
+    database.session.flush()
+    # demo templates
+    # TODO
+
+
+class CreateDemo(command.Command):
+
+    desc = 'Create demo users and contents.'
+
+    @staticmethod
+    def set_options(optparser):
+        optparser.usage += ' [application]'
+
+    @staticmethod
+    def run(parser, options, args):
+
+        try:
+            application = args[0]
+        except IndexError:
+            application = 'kansha'
+
+        (cfgfile, app, dist, conf) = util.read_application(application,
+                                                           parser.error)
+        requirement = (
+            None if not dist
+            else pkg_resources.Requirement.parse(dist.project_name)
+        )
+        data_path = (
+            None if not requirement
+            else pkg_resources.resource_filename(requirement, '/data')
+        )
+
+        (active_app, databases) = util.activate_WSGIApp(
+            app, cfgfile, conf, parser.error, data_path=data_path)
+        for (database_settings, populate) in databases:
+            database.set_metadata(*database_settings)
+        if active_app:
+            create_demo(active_app)

--- a/kansha/batch/create_demo.py
+++ b/kansha/batch/create_demo.py
@@ -18,15 +18,11 @@
 
 
 """
-Create and (re)build the search index for cards.
-It is safe to run it anytime.
+Create the demo users.
 Registered as a nagare-admin command.
 Usage :
-nagare-admin create-index <app name | config file>
+nagare-admin create-demo <app name | config file>
 """
-from io import BytesIO
-
-from retricon import retricon
 import pkg_resources
 
 from nagare import database
@@ -43,17 +39,11 @@ def create_demo(app):
     for i in xrange(1, 4):
         email = u'user%d@net-ng.com' % i
         username = u'user%d' % i
-        identicon = retricon(email.encode(), tiles=7, width=140)
-        icon_file = BytesIO()
-        identicon.save(icon_file, 'PNG')
-        assets_manager.save(
-            icon_file.getvalue(),
-            username,
-            {'filename': '%s.png' % username})
-        picture = assets_manager.get_image_url(username, 'thumb')
-        user = user_manager.create_user(username, u'password', u'user %d' % i, email, picture=picture)
+        user = user_manager.create_user(username, u'password', u'user %d' % i, email)
         user.confirm_email()
-    database.session.flush()
+        appuser = user_manager.get_app_user(username, user)
+        appuser.reset_avatar(assets_manager)
+        database.session.flush()
     # demo templates
     # TODO
 

--- a/kansha/board/comp.py
+++ b/kansha/board/comp.py
@@ -741,9 +741,6 @@ class Board(events.EventHandlerMixIn):
         """
         return set(dbm.user.id for dbm in self.data.board_members)
 
-    def get_pending_user_ids(self):
-        return set(user.id for user in self.data.get_pending_users())
-
     def set_background_image(self, new_file):
         """Set the board's background image
         In:

--- a/kansha/board/models.py
+++ b/kansha/board/models.py
@@ -207,10 +207,6 @@ class DataBoard(Entity):
         """
         DataMembership.add_member(self, user, role == 'manager')
 
-    def get_pending_users(self):
-        emails = [token.username for token in self.pending]
-        return DataUser.query.filter(DataUser.email.in_(emails))
-
 
 # Populate
 DEFAULT_LABELS = (

--- a/kansha/card_addons/members/comp.py
+++ b/kansha/card_addons/members/comp.py
@@ -105,13 +105,10 @@ class CardMembers(CardExtension):
         Return:
             - a set of ids
         """
-        return self.get_all_available_user_ids() | self.get_pending_user_ids() - set(user().id for user in self.members)
+        return self.get_all_available_user_ids() - set(user().id for user in self.members)
 
     def get_all_available_user_ids(self):
         return self.configurator.get_available_user_ids() if self.configurator else []
-
-    def get_pending_user_ids(self):
-        return self.configurator.get_pending_user_ids() if self.configurator else []
 
     @property
     def favorites(self):

--- a/kansha/card_addons/members/models.py
+++ b/kansha/card_addons/members/models.py
@@ -69,8 +69,9 @@ class DataMembership(Entity):
 
     @classmethod
     def add_card_members_from_emails(cls, card, emails):
-        """Provisinal: will take memberships instead of emails."""
-        query = cls.query.join(DataUser).filter(DataUser.email.in_(emails),
+        """Provisional: will take memberships instead of emails."""
+        query = cls.query.join(DataUser).filter(sa.or_(DataUser.email.in_(emails),
+                                                       DataUser.email_to_confirm.in_(emails)),
                                                 DataMembership.board == card.column.board)
         memberships = query.all()
         for membership in memberships:

--- a/kansha/populate.py
+++ b/kansha/populate.py
@@ -9,7 +9,6 @@
 #--
 
 from .board.models import create_template_empty, create_template_todo
-from .user import usermanager
 
 
 def populate():
@@ -17,4 +16,3 @@ def populate():
     """
     create_template_empty()
     create_template_todo()
-    usermanager.UserManager().populate()

--- a/kansha/user/comp.py
+++ b/kansha/user/comp.py
@@ -56,7 +56,7 @@ class User(security_common.User):
 
     @property
     def email(self):
-        return self.data.email
+        return self.data.email or self.data.email_to_confirm
 
     @property
     def source(self):

--- a/kansha/user/models.py
+++ b/kansha/user/models.py
@@ -60,7 +60,7 @@ class DataUser(Entity):
         primary_key=True, nullable=False)
     source = Field(Unicode(255), nullable=False, primary_key=True)
     fullname = Field(Unicode(255), nullable=False)
-    email = Field(Unicode(255), nullable=True)
+    email = Field(Unicode(255), nullable=True, unique=True, index=True)
     picture = Field(Unicode(255), nullable=True)
     language = Field(Unicode(255), default=u"en", nullable=True)
     email_to_confirm = Field(Unicode(255))
@@ -69,7 +69,7 @@ class DataUser(Entity):
     registration_date = Field(DateTime, nullable=False)
     last_login = Field(DateTime, nullable=True)
     last_board = OneToOne('DataBoard', inverse='last_users')
-    history = OneToMany('DataHistory')
+    # history = OneToMany('DataHistory')
 
     def __init__(self, username, password, fullname, email,
                  source=u'application', picture=None, **kw):
@@ -161,4 +161,6 @@ class DataUser(Entity):
 
     @classmethod
     def search(cls, value):
-        return cls.query.filter(cls.fullname.ilike('%' + value + '%') | cls.email.ilike('%' + value + '%'))
+        return cls.query.filter(cls.fullname.ilike('%' + value + '%') |
+                                cls.email.ilike('%' + value + '%') |
+                                cls.email_to_confirm.ilike('%' + value + '%'))

--- a/kansha/user/usermanager.py
+++ b/kansha/user/usermanager.py
@@ -92,12 +92,6 @@ class UserManager(object):
             token_gen.reset_token(token.token)
         return user
 
-    def populate(self):
-        # Create users
-        for i in xrange(1, 4):
-            user = self.create_user(u'user%d' % i, u'password', u'user %d' % i, u'user%d@net-ng.com' % i)
-            user.confirm_email()
-
 ###### TODO: Move the defintions below somewhere else ##########
 
 class NewMember(object):

--- a/kansha/user/usermanager.py
+++ b/kansha/user/usermanager.py
@@ -13,9 +13,9 @@ from datetime import datetime, timedelta
 from nagare.namespaces import xhtml
 from nagare import component, i18n
 
-from kansha.toolbox import autocomplete
-from .models import DataUser
 from .comp import User
+from .models import DataUser
+from kansha.toolbox import autocomplete
 
 
 class UserManager(object):
@@ -91,6 +91,7 @@ class UserManager(object):
                 token.board.add_member(user)
             token_gen.reset_token(token.token)
         return user
+
 
 ###### TODO: Move the defintions below somewhere else ##########
 

--- a/kansha/user/usermanager.py
+++ b/kansha/user/usermanager.py
@@ -122,8 +122,9 @@ class NewMember(object):
         Return:
          - list of tuple (email, HTML string)
         """
+        # FIXME: dont access data attributes!
         h = xhtml.Renderer(static_url=static_url)
-        return [(u.email, component.Component(UserManager.get_app_user(u.username, data=u)).render(h, "search").write_htmlstring())
+        return [(u.email or u.email_to_confirm, component.Component(UserManager.get_app_user(data=u)).render(h, "search").write_htmlstring())
                 for u in self.autocomplete_method(value)]
 
 

--- a/kansha/user/view.py
+++ b/kansha/user/view.py
@@ -136,7 +136,7 @@ def render_User_detailed(self, h, comp, *args):
 @presentation.render_for(User, model="friend")
 def render_User_friend(self, h, comp, *args):
     h << h.a(comp.render(h, "avatar")).action(
-        remote.Action(lambda: comp.answer([self.data.email])))
+        remote.Action(lambda: comp.answer([self.data.email or self.data.email_to_confirm])))
     return h.root
 
 

--- a/kansha/user/view.py
+++ b/kansha/user/view.py
@@ -24,7 +24,7 @@ def render_User(self, h, comp, *args):
     h << comp.render(h, "avatar")
     with h.div(class_="name"):
         h << comp.render(h, model="fullname")
-        h << h.span(self.data.email, class_="email")
+        h << h.span(self.data.email or self.data.email_to_confirm, class_="email")
     return h.root
 
 

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
       alembic-upgrade = kansha.alembic.admin:AlembicUpgradeCommand
       create-index = kansha.batch.create_index:ReIndex
       save-config = kansha.batch.save_config:SaveConfig
+      create-demo = kansha.batch.create_demo:CreateDemo
 
       [kansha.services]
       authentication = kansha.services.authentication_repository:AuthenticationsRepository

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'Babel',
         'dateutils',
         'docutils',
+        'identicon',
         'nagare[database,i18n]==0.4.1.post473',
         'nagare-services',
         'oauth2==1.5.211',

--- a/static/css/themes/home.css
+++ b/static/css/themes/home.css
@@ -24,6 +24,8 @@
     display: inline-block;
     visibility: hidden;
     overflow: hidden;
+    margin: 0;
+    padding: 0;
 }
 
 .home .boards ul.board-labels li:hover .add,

--- a/static/css/themes/kansha.css
+++ b/static/css/themes/kansha.css
@@ -129,8 +129,8 @@ i.icon {
 .board-labels .avatar img,
 .card .avatar img,
 .card-actions .avatar img {
-    max-height: 24px;
-    max-width: 24px;
+    max-height: 21px;
+    max-width: 21px;
 }
 
 /*Error page*/

--- a/static/css/themes/kansha.css
+++ b/static/css/themes/kansha.css
@@ -251,7 +251,7 @@ i.icon {
 }
 
 .avatar img {
-    max-width: 30px;
+    /*max-width: 30px;*/
     height: 28px;
     display: block
 }

--- a/static/css/themes/kansha_flat/kansha.css
+++ b/static/css/themes/kansha_flat/kansha.css
@@ -162,7 +162,7 @@ a:hover .ico-btn {
 .board-labels i.ico-btn,
 .card i.ico-btn,
 .card-actions i.ico-btn {
-    font-size: 25px;
+    font-size: 21px;
 }
 
 /*Error page*/


### PR DESCRIPTION
- Create identicons for users registering throught 'Sign up' form. They can change it once logged on.
- Smaller avatars on cards and boards.
- Demo users are not created by default anymore, use `kansha-admin create-demo` if you need them.

Replaces #203.
Fixes #179.

![screenshot from 2017-01-05 11-54-31](https://cloud.githubusercontent.com/assets/7592443/21678146/c8d7fcf0-d33d-11e6-9a8f-1e3910f15406.png)

![screenshot from 2017-01-03 16-30-59](https://cloud.githubusercontent.com/assets/7592443/21612659/689b0a6a-d1d2-11e6-938b-3564a27fb78b.png)
