### PR TITLE
fix card creation button at the bottom of the lists

### DIFF
--- a/static/css/themes/board.css
+++ b/static/css/themes/board.css
@@ -273,7 +273,6 @@ textarea.expanded {
     bottom: 0;
     width: 100%;
     text-align: center;
-    padding: 8px 0;
 }
 
 .list .list-footer-disabled {
@@ -286,6 +285,7 @@ textarea.expanded {
 
 .list .list-footer .link-small {
     display: block;
+    padding: 8px 0;
 }
 
 .list .list-footer .link-small strong {


### PR DESCRIPTION
Before this small CSS fix, parts of the button were not clickable because the top and bottom padding was around the link instead of being inside the link.

Here is the hovered element when the cursor is in the padding:

before
![screenshot_20170131_173904](https://cloud.githubusercontent.com/assets/130780/22474775/33b321e0-e7dd-11e6-923d-476222bf8fed.png)

after
![screenshot_20170131_173927](https://cloud.githubusercontent.com/assets/130780/22474782/3c451d68-e7dd-11e6-9a1c-3bdcaa2b74ce.png)
